### PR TITLE
better flake inputs + overhaul dependency management

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
@@ -29,12 +27,4 @@ jobs:
 
       - name: Build
         run: |
-          nix-build --fallback -A packages.x86_64-linux.${{ matrix.package }}
-
-      - if: ${{ github.action_repository == 'ryanccn/osmosis' && github.event_name != 'pull_request' }}
-        name: Push cache to Cachix
-        run: |
-          # shellcheck disable=SC2046
-          nix-store -qR --include-outputs $(nix-store -qd $(nix-build -A packages.x86_64-linux.${{ matrix.package }})) \
-            | grep -v '\.drv$' \
-            | cachix push osmosis
+          nix build --accept-flake-config --fallback .#${{ matrix.package }}

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -27,13 +27,14 @@ jobs:
           name: osmosis
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      - name: Setup swap
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 15
+
       - name: Build
         run: |
-          # retry up to 2 times if build fails as 
-          # sometimes cached dependencies can fail to download
-          for _ in {0..2}; do
-            nix-build -A packages.x86_64-linux.${{ matrix.package }} && break
-          done
+          nix-build --fallback -A packages.x86_64-linux.${{ matrix.package }}
 
       - if: ${{ github.action_repository == 'ryanccn/osmosis' && github.event_name != 'pull_request' }}
         name: Push cache to Cachix

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -27,11 +27,6 @@ jobs:
           name: osmosis
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Setup swap
-        uses: pierotofy/set-swap-space@v1.0
-        with:
-          swap-size-gb: 15
-
       - name: Build
         run: |
           nix-build --fallback -A packages.x86_64-linux.${{ matrix.package }}

--- a/flake.lock
+++ b/flake.lock
@@ -307,16 +307,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1683014792,
-        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
+        "lastModified": 1677932085,
+        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -78,12 +78,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -239,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678737365,
-        "narHash": "sha256-oRdONay5u7oJID2uDlgJgg7F/tCq2oy8W6voMGVHis0=",
+        "lastModified": 1681331676,
+        "narHash": "sha256-zOzkx39AALckaAtW175ueBOUpy/xPtrC8nnp9lHYVt0=",
         "owner": "nixified-ai",
         "repo": "flake",
-        "rev": "59bba5c414608ee2e70a9aba3ed06a734bb08b7c",
+        "rev": "422bf5503375cfc5bd526862ae0b67c55f1c8705",
         "type": "github"
       },
       "original": {
@@ -304,11 +307,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1678898370,
-        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "lastModified": 1683014792,
+        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
         "type": "github"
       },
       "original": {
@@ -332,11 +335,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1678976941,
-        "narHash": "sha256-skNr08frCwN9NO+7I77MjOHHAw+L410/37JknNld+W4=",
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "32b1dbedfd77892a6e375737ef04d8efba634e9e",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
         "type": "github"
       },
       "original": {
@@ -376,6 +379,21 @@
         "nixified-ai": "nixified-ai",
         "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -50,30 +50,7 @@
       };
   in
     eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        # running tifffile's tests can cause oom errors on systems
-        # with <= 16GB of memory
-        overlays = [
-          (final: prev: {
-            python3 = prev.python3.override {
-              packageOverrides = prev.lib.composeManyExtensions [
-                (
-                  _: prev: {
-                    tifffile = prev.tifffile.overridePythonAttrs (
-                      _: {
-                        doCheck = false;
-                      }
-                    );
-                  }
-                )
-              ];
-            };
-
-            python3Packages = final.python3.pkgs;
-          })
-        ];
-      };
+      pkgs = import nixpkgs {inherit system;};
     in {
       checks = {
         pre-commit-check = pre-commit-hooks.lib.${system}.run {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "nixpkgs/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,30 @@
       };
   in
     eachDefaultSystem (system: let
-      pkgs = import nixpkgs {inherit system;};
+      pkgs = import nixpkgs {
+        inherit system;
+        # running tifffile's tests can cause oom errors on systems
+        # with <= 16GB of memory
+        overlays = [
+          (final: prev: {
+            python3 = prev.python3.override {
+              packageOverrides = prev.lib.composeManyExtensions [
+                (
+                  _: prev: {
+                    tifffile = prev.tifffile.overridePythonAttrs (
+                      _: {
+                        doCheck = false;
+                      }
+                    );
+                  }
+                )
+              ];
+            };
+
+            python3Packages = final.python3.pkgs;
+          })
+        ];
+      };
     in {
       checks = {
         pre-commit-check = pre-commit-hooks.lib.${system}.run {

--- a/nix/coremltools.nix
+++ b/nix/coremltools.nix
@@ -4,15 +4,6 @@
   ...
 }: let
   inherit (python3Packages) buildPythonPackage;
-  protobuf = python3Packages.protobuf.overridePythonAttrs (_: rec {
-    version = "3.20.3";
-    src = fetchFromGitHub {
-      owner = "protocolbuffers";
-      repo = "protobuf";
-      rev = "v${version}";
-      sha256 = "sha256-u/1Yb8+mnDzc3OwirpGESuhjkuKPgqDAvlgo3uuzbbk=";
-    };
-  });
 in
   buildPythonPackage rec {
     pname = "coremltools";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,24 +19,23 @@
     python3'.pkgs;
 
   aipython3-nvidia = mkPythonPackages [
-    myOverlay.osmosisFixes
-    myOverlay.osmosisPackages
     aipythonOverlay.fixPackages
     aipythonOverlay.extraDeps
     aipythonOverlay.torchCuda
+    myOverlay.osmosisFixes
+    myOverlay.osmosisPackages
   ];
 
   aipython3-amd = mkPythonPackages [
-    myOverlay.osmosisFixes
-    myOverlay.osmosisPackages
     aipythonOverlay.fixPackages
     aipythonOverlay.extraDeps
     aipythonOverlay.torchRocm
+    myOverlay.osmosisFixes
+    myOverlay.osmosisPackages
   ];
 
   mkOsmosis = args: callPackage ./osmosis.nix ({inherit version;} // args);
 in rec {
-  inherit aipython3-nvidia;
   coremltools = callPackage ./coremltools.nix {};
   osmosis-frontend = callPackage ./osmosis-frontend.nix {};
   osmosis-nvidia = mkOsmosis {

--- a/nix/osmosis.nix
+++ b/nix/osmosis.nix
@@ -3,7 +3,6 @@
   stdenv,
   aipython3,
   coremltools,
-  fetchFromGitHub,
   fetchPypi,
   osmosis-frontend,
   version,
@@ -41,25 +40,7 @@
     };
   });
 
-  # pyproject.toml requires ~= 5.3.2
-  # TODO: remove this when it gets updated in nixpkgs
-  flask-socketio = aipython3.flask-socketio.overridePythonAttrs (_: rec {
-    version = "5.3.3";
-    src = fetchFromGitHub {
-      owner = "miguelgrinberg";
-      repo = "Flask-SocketIO";
-      rev = "v${version}";
-      sha256 = "sha256-oqy6tSk569QaSkeNsyXuaD6uUB3yuEFg9Jwh5rneyOE=";
-    };
-
-    checkInputs = with aipython3; [
-      coverage
-      pytestCheckHook
-      redis
-    ];
-  });
-
-  omegaconf = aipython3.omegaconf.overridePythonAttrs (_: rec {
+  omegaconf = aipython3.omegaconf.overridePythonAttrs (_: {
     # this fails because of a deprecation warning, not anything serious
     doCheck = false;
   });
@@ -83,7 +64,7 @@
   };
 
   # allows for cuda support
-  xformers = buildPythonPackage rec {
+  xformers = buildPythonPackage {
     pname = "xformers";
     version = "0.0.16";
     format = "wheel";

--- a/nix/osmosis.nix
+++ b/nix/osmosis.nix
@@ -3,7 +3,6 @@
   stdenv,
   aipython3,
   coremltools,
-  fetchPypi,
   osmosis-frontend,
   version,
   isNvidia ? false,
@@ -11,77 +10,6 @@
 }: let
   inherit (lib) cleanSource licenses maintainers;
   inherit (aipython3) buildPythonPackage;
-
-  # for some reason this doesn't build by default...
-  compel = aipython3.compel.overridePythonAttrs (_: rec {
-    pname = "compel";
-    version = "1.0.5";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-vpMXDsB+7t+ZxlSt795jsBZ76ZqbQlTe0XhAuA/LfFI=";
-    };
-
-    propagatedBuildInputs = with aipython3; [
-      setuptools
-      diffusers
-      pyparsing
-      transformers
-      torch
-    ];
-  });
-
-  accelerate = aipython3.accelerate.overridePythonAttrs (_: rec {
-    version = "0.17.1";
-    src = fetchPypi {
-      pname = "accelerate";
-      inherit version;
-      sha256 = "sha256-+K024c4YaWC7l1vRYn3LCWLCBGZY0+wWF1g+vcWY9Zk=";
-    };
-  });
-
-  omegaconf = aipython3.omegaconf.overridePythonAttrs (_: {
-    # this fails because of a deprecation warning, not anything serious
-    doCheck = false;
-  });
-
-  pyre-extensions = buildPythonPackage rec {
-    pname = "pyre-extensions";
-    version = "0.0.23";
-    format = "wheel";
-    src = fetchPypi rec {
-      pname = "pyre_extensions";
-      inherit version format;
-      sha256 = "sha256-6UX99BExcs7FF8Xa7KVvYfZjL9W42BZfElPIhlyH5is=";
-      dist = python;
-      python = "py3";
-    };
-
-    propagatedBuildInputs = with aipython3; [
-      typing-extensions
-      typing-inspect
-    ];
-  };
-
-  # allows for cuda support
-  xformers = buildPythonPackage {
-    pname = "xformers";
-    version = "0.0.16";
-    format = "wheel";
-
-    src = builtins.fetchurl {
-      url = "https://files.pythonhosted.org/packages/b3/90/178f8dec2d3f9b60f4d29954bc2d605ee8e8e762094047fc4ec0b94d13c0/xformers-0.0.16-cp310-cp310-manylinux2014_x86_64.whl";
-      sha256 = "sha256:03kgf90zz3kfz05zx9sm0cr5xwzlgp6qhr4qyfz9ddjq69k7fjm6";
-    };
-
-    propagatedBuildInputs = with aipython3; [
-      torch
-      numpy
-      pyre-extensions
-    ];
-
-    doCheck = false;
-  };
 in
   buildPythonPackage {
     pname = "osmosis";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -47,6 +47,9 @@ in {
       };
     });
 
+    # tests fail, not really sure why...?
+    tensorboard = prev.tensorboard.overridePythonAttrs (_: {doCheck = false;});
+
     # running tifffile's tests can cause oom errors on systems
     # with <= 16GB of memory
     tifffile = prev.tifffile.overridePythonAttrs (_: {doCheck = false;});

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -12,13 +12,13 @@ in {
       };
     });
 
-    # for some reason this doesn't build by default...
-    compel = prev.compel.overridePythonAttrs (_: rec {
-      pname = "compel";
+    # pyproject.toml requires ~=1.0.5
+    compel = prev.compel.overridePythonAttrs (prev: rec {
       version = "1.0.5";
 
       src = fetchPypi {
-        inherit pname version;
+        inherit (prev) pname;
+        inherit version;
         sha256 = "sha256-vpMXDsB+7t+ZxlSt795jsBZ76ZqbQlTe0XhAuA/LfFI=";
       };
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,96 @@
+pkgs: let
+  inherit (pkgs) fetchFromGitHub fetchPypi;
+in {
+  osmosisFixes = final: prev: {
+    # osmosis requires a decently new version of accelerate
+    accelerate = prev.accelerate.overridePythonAttrs (_: rec {
+      version = "0.17.1";
+      src = fetchPypi {
+        pname = "accelerate";
+        inherit version;
+        sha256 = "sha256-+K024c4YaWC7l1vRYn3LCWLCBGZY0+wWF1g+vcWY9Zk=";
+      };
+    });
+
+    # for some reason this doesn't build by default...
+    compel = prev.compel.overridePythonAttrs (_: rec {
+      pname = "compel";
+      version = "1.0.5";
+
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "sha256-vpMXDsB+7t+ZxlSt795jsBZ76ZqbQlTe0XhAuA/LfFI=";
+      };
+
+      propagatedBuildInputs = with final; [
+        setuptools
+        diffusers
+        pyparsing
+        transformers
+        torch
+      ];
+    });
+
+    # this fails because of a deprecation warning, not anything serious
+    omegaconf = prev.omegaconf.overridePythonAttrs (_: {
+      doCheck = false;
+    });
+
+    # coremltools requires protobuf >= 3.10, <= 4.0.0
+    protobuf = prev.protobuf.overridePythonAttrs (_: rec {
+      version = "3.20.3";
+      src = fetchFromGitHub {
+        owner = "protocolbuffers";
+        repo = "protobuf";
+        rev = "v${version}";
+        sha256 = "sha256-u/1Yb8+mnDzc3OwirpGESuhjkuKPgqDAvlgo3uuzbbk=";
+      };
+    });
+
+    # running tifffile's tests can cause oom errors on systems
+    # with <= 16GB of memory
+    tifffile = prev.tifffile.overridePythonAttrs (_: {doCheck = false;});
+  };
+
+  osmosisPackages = final: prev: let
+    inherit (prev) buildPythonPackage;
+  in {
+    pyre-extensions = buildPythonPackage rec {
+      pname = "pyre-extensions";
+      version = "0.0.23";
+      format = "wheel";
+      src = fetchPypi rec {
+        pname = "pyre_extensions";
+        inherit version format;
+        sha256 = "sha256-6UX99BExcs7FF8Xa7KVvYfZjL9W42BZfElPIhlyH5is=";
+        dist = python;
+        python = "py3";
+      };
+
+      propagatedBuildInputs = with final; [
+        typing-extensions
+        typing-inspect
+      ];
+    };
+
+    # allows for cuda support
+    xformers = buildPythonPackage {
+      pname = "xformers";
+      version = "0.0.16";
+      format = "wheel";
+
+      src = builtins.fetchurl {
+        url = "https://files.pythonhosted.org/packages/b3/90/178f8dec2d3f9b60f4d29954bc2d605ee8e8e762094047fc4ec0b94d13c0/xformers-0.0.16-cp310-cp310-manylinux2014_x86_64.whl";
+        sha256 = "sha256:03kgf90zz3kfz05zx9sm0cr5xwzlgp6qhr4qyfz9ddjq69k7fjm6";
+      };
+
+      propagatedBuildInputs = with final; [
+        torch
+        numpy
+        pyre-extensions
+      ];
+
+      doCheck = false;
+    };
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -31,6 +31,24 @@ in {
       ];
     });
 
+    # pyproject.toml requires ~= 5.3.2
+    # TODO: remove this when it gets updated in nixpkgs
+    flask-socketio = prev.flask-socketio.overridePythonAttrs (_: rec {
+      version = "5.3.3";
+      src = fetchFromGitHub {
+        owner = "miguelgrinberg";
+        repo = "Flask-SocketIO";
+        rev = "v${version}";
+        sha256 = "sha256-oqy6tSk569QaSkeNsyXuaD6uUB3yuEFg9Jwh5rneyOE=";
+      };
+
+      checkInputs = with prev; [
+        coverage
+        pytestCheckHook
+        redis
+      ];
+    });
+
     # this fails because of a deprecation warning, not anything serious
     omegaconf = prev.omegaconf.overridePythonAttrs (_: {
       doCheck = false;


### PR DESCRIPTION
~~updated flake inputs~~ matched our flake inputs with nixified-ai's. this allows for our builds to reproduce the same dependencies, which in turn saves on disk space for those who use this *and* nixified-ai projects, as well as prevents us from building what is basically the same thing twice.

the way we manage dependencies has also been changed: instead of overriding them all in the osmosis derivation, an overlay is applied with nixified-ai's packages. this lets us easily integrate our packages with theirs, along with making future overrides both easier and more consistent